### PR TITLE
Add STM32F411 black pill support

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -11,14 +11,17 @@ This project can be built with the Arduino IDE using either a Teensy 4.x or an S
 - **Libraries**
   - `LiquidCrystal`
   - `FlexCAN_T4` (Teensy only)
-  - `STM32_CAN` (install via Library Manager for STM32)
+  - `STM32_CAN` (install via Library Manager for STM32). This library replaces
+    the old "STM32duino CAN" package and is maintained by Pasi Kemppainen.
 
 ## Steps
 
 1. Open the Arduino IDE and install the required board support using **Tools → Board → Boards Manager…**
 2. For the black pill, select **Generic STM32F4 series → BlackPill F411CE** from the board list.
 3. Use **Tools → Manage Libraries…** to install the **CAN bus Library for Arduino STM32** (`STM32_CAN`) if it is not already present.
-4. Create a file named `hal_conf_extra.h` next to the sketch with the following line to enable CAN support:
+4. Create a file named `hal_conf_extra.h` next to the sketch with the following
+   line to enable CAN support (this repository already ships with such a file,
+   just make sure it lives in the same folder as the `.ino`):
    ```
    #define HAL_CAN_MODULE_ENABLED
    ```

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -11,14 +11,18 @@ This project can be built with the Arduino IDE using either a Teensy 4.x or an S
 - **Libraries**
   - `LiquidCrystal`
   - `FlexCAN_T4` (Teensy only)
-  - `STM32duino CAN` (install via Library Manager for STM32)
+  - `STM32_CAN` (install via Library Manager for STM32)
 
 ## Steps
 
 1. Open the Arduino IDE and install the required board support using **Tools → Board → Boards Manager…**
 2. For the black pill, select **Generic STM32F4 series → BlackPill F411CE** from the board list.
-3. Use **Tools → Manage Libraries…** to install the `STM32duino CAN` library if it is not already present.
-4. Connect your board and select the appropriate upload method (for the black pill usually `STM32CubeProgrammer (DFU)` or `Serial`).
-5. Open `volvo-cem-cracker.ino`, choose the correct board and port, then click **Upload**.
+3. Use **Tools → Manage Libraries…** to install the **CAN bus Library for Arduino STM32** (`STM32_CAN`) if it is not already present.
+4. Create a file named `hal_conf_extra.h` next to the sketch with the following line to enable CAN support:
+   ```
+   #define HAL_CAN_MODULE_ENABLED
+   ```
+5. Connect your board and select the appropriate upload method (for the black pill usually `STM32CubeProgrammer (DFU)` or `Serial`).
+6. Open `volvo-cem-cracker.ino`, choose the correct board and port, then click **Upload**.
 
 The sketch uses `Serial` for the console and `Serial2` as the K-line port when building for STM32. Adjust the wiring accordingly.

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,0 +1,24 @@
+# Building and Uploading
+
+This project can be built with the Arduino IDE using either a Teensy 4.x or an STM32F411 "black pill" board.
+
+## Requirements
+
+- **Arduino IDE** (1.8.x or newer)
+- **Board packages**
+  - PJRC Teensy (for Teensy boards)
+  - STM32 MCU based boards (by STMicroelectronics) for the F411
+- **Libraries**
+  - `LiquidCrystal`
+  - `FlexCAN_T4` (Teensy only)
+  - `STM32duino CAN` (install via Library Manager for STM32)
+
+## Steps
+
+1. Open the Arduino IDE and install the required board support using **Tools → Board → Boards Manager…**
+2. For the black pill, select **Generic STM32F4 series → BlackPill F411CE** from the board list.
+3. Use **Tools → Manage Libraries…** to install the `STM32duino CAN` library if it is not already present.
+4. Connect your board and select the appropriate upload method (for the black pill usually `STM32CubeProgrammer (DFU)` or `Serial`).
+5. Open `volvo-cem-cracker.ino`, choose the correct board and port, then click **Upload**.
+
+The sketch uses `Serial` for the console and `Serial2` as the K-line port when building for STM32. Adjust the wiring accordingly.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 A research project grown out of curiosity. Cracks 6 bytes of pin code via High Speed CAN-bus in under 20 minutes.
 
+The repository includes a **BUILDING.md** file with step-by-step instructions
+for compiling the sketch on either a Teensy 4.x or an STM32F411 "black pill".
+When targeting STM32 remember to copy `hal_conf_extra.h` next to the `.ino` and
+install the `STM32_CAN` library from the Arduino Library Manager.
+
 See **BUILDING.md** for instructions on compiling and uploading the sketch on Teensy or STM32 boards.
 
 ## Supported platforms:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A research project grown out of curiosity. Cracks 6 bytes of pin code via High Speed CAN-bus in under 20 minutes.
 
+See **BUILDING.md** for instructions on compiling and uploading the sketch on Teensy or STM32 boards.
+
 ## Supported platforms:
 
 * P1:

--- a/hal_conf_extra.h
+++ b/hal_conf_extra.h
@@ -1,0 +1,1 @@
+#define HAL_CAN_MODULE_ENABLED

--- a/volvo-cem-cracker.ino
+++ b/volvo-cem-cracker.ino
@@ -16,12 +16,21 @@
 
 /* end of tunable parameters */
 
-#include <stdio.h>
-#include <FlexCAN_T4.h>
-#include <LiquidCrystal.h>
+#if defined(__IMXRT1062__)
+#define PLATFORM_TEENSY
+#endif
+#if defined(ARDUINO_ARCH_STM32)
+#define PLATFORM_STM32
+#endif
 
-#if !defined(__IMXRT1062__)
-#error Unsupported Teensy model, need 4.x
+#include <LiquidCrystal.h>
+#include <stdio.h>
+#include <stdarg.h>
+
+#if defined(PLATFORM_STM32)
+#include <CAN.h>           /* STM32 CAN library */
+#else
+#include <FlexCAN_T4.h>
 #endif
 
 uint32_t cem_reply_min;
@@ -31,16 +40,27 @@ uint32_t cem_reply_max;
 #define AVERAGE_DELTA_MIN     -8  /* buckets to look at before the rolling average */
 #define AVERAGE_DELTA_MAX     12  /* buckets to look at after the rolling average  */
 
-#define CAN_L_PIN      PIND2     /* CAN Rx pin connected to digital pin 2 */
-#define CALC_BYTES_PIN PIND3     /* calculated bytes selection to digital pin 3 */
+#define CAN_L_PIN      2         /* CAN Rx pin connected to digital pin 2 */
+#define CALC_BYTES_PIN 3         /* calculated bytes selection to digital pin 3 */
 #define ABORT_PIN      14        /* abort cracking request */
 
 #define CAN_500KBPS 500000      /* 500 Kbit speed */
 #define CAN_250KBPS 250000      /* 250 Kbit speed */
 #define CAN_125KBPS 125000      /* 125 Kbit speed */
 
+#if defined(PLATFORM_STM32)
+#define KLINE_SERIAL Serial2
+#else
+#define KLINE_SERIAL Serial3
+#endif
+
+#if defined(PLATFORM_STM32)
+CANClass can_hs;
+CANClass can_ls;
+#else
 FlexCAN_T4<CAN1, RX_SIZE_256, TX_SIZE_16> can_hs;
 FlexCAN_T4<CAN2, RX_SIZE_256, TX_SIZE_16> can_ls;
+#endif
 
 typedef enum {
   CAN_HS,       /* high-speed bus */
@@ -49,11 +69,40 @@ typedef enum {
 
 /* use the ARM cycle counter as the time-stamp */
 
+#if defined(PLATFORM_STM32)
+#define TSC DWT->CYCCNT
+#else
 #define TSC ARM_DWT_CYCCNT
+#endif
 
+#if defined(PLATFORM_TEENSY)
 #define printf Serial.printf
+#else
+static inline void serial_printf(const char *fmt, ...)
+{
+  char buf[128];
+  va_list ap;
+  va_start(ap, fmt);
+  vsnprintf(buf, sizeof(buf), fmt, ap);
+  va_end(ap);
+  Serial.print(buf);
+}
+#define printf serial_printf
+#endif
+
+#ifndef F_CPU_ACTUAL
+#define F_CPU_ACTUAL F_CPU
+#endif
 
 #define CAN_MSG_SIZE    8       /* messages are always 8 bytes */
+
+#if defined(PLATFORM_STM32)
+typedef struct {
+  uint32_t id;
+  uint8_t  buf[CAN_MSG_SIZE];
+  uint8_t  len;
+} CAN_message_t;
+#endif
 
 #define CEM_HS_ECU_ID   0x50    /* CEM ECU id on the high-speed CAN bus */
 #define CEM_LS_ECU_ID   0x40    /* CEM ECU id on the low-speed CAN bus */
@@ -151,7 +200,11 @@ uint32_t calc_bytes = CALC_BYTES;
 
 /* Teensy function to set the core's clock rate */
 
+#ifdef PLATFORM_TEENSY
 extern "C" uint32_t set_arm_clock (uint32_t freq);
+#else
+static inline uint32_t set_arm_clock (uint32_t freq) { return freq; }
+#endif
 
 /* Initialize the LCD library for use with the Hitachi HD44780
  * controller using the following interface pins:
@@ -212,6 +265,20 @@ void abortIsr (void)
  * Returns: N/A
  */
 
+#if defined(PLATFORM_STM32)
+void canMsgSend (can_bus_id_t bus, uint32_t id, uint8_t *data, bool verbose)
+{
+  CANClass &can = (bus == CAN_HS) ? can_hs : can_ls;
+  if (verbose) {
+    printf ("CAN_%cS ---> ID=%08x data=%02x %02x %02x %02x %02x %02x %02x %02x\n",
+            bus == CAN_HS ? 'H' : 'L',
+            id, data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7]);
+  }
+  can.beginExtendedPacket(id);
+  can.write(data, CAN_MSG_SIZE);
+  can.endPacket();
+}
+#else
 void canMsgSend (can_bus_id_t bus, uint32_t id, uint8_t *data, bool verbose)
 {
   CAN_message_t msg;
@@ -242,6 +309,7 @@ void canMsgSend (can_bus_id_t bus, uint32_t id, uint8_t *data, bool verbose)
       break;
   }
 }
+#endif
 
 CAN_message_t can_hs_event_msg;
 CAN_message_t can_ls_event_msg;
@@ -259,6 +327,30 @@ volatile bool can_ls_event_msg_available = false;
 
 bool canMsgReceive (can_bus_id_t bus, uint32_t *id, uint8_t *data, uint32_t wait, bool verbose)
 {
+#if defined(PLATFORM_STM32)
+  CANClass &can = (bus == CAN_HS) ? can_hs : can_ls;
+  uint32_t start = millis();
+  while ((millis() - start) < wait) {
+    int packetSize = can.parsePacket();
+    if (packetSize) {
+      uint32_t rxId = can.packetId();
+      if (id)
+        *id = rxId;
+      if (data) {
+        for (int i = 0; i < CAN_MSG_SIZE && i < packetSize; i++)
+          data[i] = can.read();
+      } else {
+        while (can.available())
+          can.read();
+      }
+      if (verbose) {
+        printf("CAN_%cS <--- ID=%08x\n", bus == CAN_HS ? 'H' : 'L', rxId);
+      }
+      return true;
+    }
+  }
+  return false;
+#else
   uint8_t *pData;
   uint32_t canId = 0;
   bool     ret = false;
@@ -310,6 +402,7 @@ bool canMsgReceive (can_bus_id_t bus, uint32_t *id, uint8_t *data, uint32_t wait
 
   return ret;
 }
+#endif
 
 /*******************************************************************************
  *
@@ -1073,11 +1166,19 @@ bool cemCrackPin (uint32_t maxBytes, bool verbose)
  * Returns: N/A
  */
 
+#if defined(PLATFORM_STM32)
+void can_hs_event(CAN_message_t &msg)
+{
+  can_hs_event_msg = msg;
+  can_hs_event_msg_available = true;
+}
+#else
 void can_hs_event (const CAN_message_t &msg)
 {
   can_hs_event_msg = msg;
   can_hs_event_msg_available = true;
 }
+#endif
 
 /*******************************************************************************
  *
@@ -1086,11 +1187,19 @@ void can_hs_event (const CAN_message_t &msg)
  * Returns: N/A
  */
 
+#if defined(PLATFORM_STM32)
+void can_ls_event(CAN_message_t &msg)
+{
+  can_ls_event_msg = msg;
+  can_ls_event_msg_available = true;
+}
+#else
 void can_ls_event (const CAN_message_t &msg)
 {
   can_ls_event_msg = msg;
   can_ls_event_msg_available = true;
 }
+#endif
 
 /*******************************************************************************
  *
@@ -1101,12 +1210,17 @@ void can_ls_event (const CAN_message_t &msg)
 
 void can_ls_init (uint32_t baud)
 {
+#if defined(PLATFORM_STM32)
+  can_ls.begin(baud);
+  can_ls.attachInterrupt(can_ls_event);
+#else
   can_ls.begin ();
   can_ls.setBaudRate (baud);
   can_ls.enableFIFO ();
   can_ls.enableFIFOInterrupt ();
   can_ls.setFIFOFilter (ACCEPT_ALL);
   can_ls.onReceive (can_ls_event);
+#endif
   printf ("CAN low-speed init done.\n");
 }
 
@@ -1119,12 +1233,17 @@ void can_ls_init (uint32_t baud)
 
 void can_hs_init (uint32_t baud)
 {
+#if defined(PLATFORM_STM32)
+  can_hs.begin(baud);
+  can_hs.attachInterrupt(can_hs_event);
+#else
   can_hs.begin ();
   can_hs.setBaudRate (baud);
   can_hs.enableFIFO ();
   can_hs.enableFIFOInterrupt ();
   can_hs.setFIFOFilter (ACCEPT_ALL);
   can_hs.onReceive (can_hs_event);
+#endif
   printf ("CAN high-speed init done.\n");
 }
 
@@ -1151,7 +1270,7 @@ void k_line_keep_alive ()
 {
   uint8_t msg[] = { 0x84, 0x40, 0x13, 0xb2, 0xf0, 0x03, 0x7c };
 
-  Serial3.write (msg, sizeof(msg));
+  KLINE_SERIAL.write (msg, sizeof(msg));
 }
 
 /*******************************************************************************
@@ -1288,14 +1407,18 @@ void setup (void)
   /* set up the serial port */
 
   Serial.begin (115200);
-  Serial3.begin (10800); /* K-Line */
+  KLINE_SERIAL.begin (10800); /* K-Line */
 
   delay (3000);
 
   /* enable the time stamp counter */
-
+#if defined(PLATFORM_STM32)
+  CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
+  DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk;
+#else
   ARM_DEMCR |= ARM_DEMCR_TRCENA;
   ARM_DWT_CTRL |= ARM_DWT_CTRL_CYCCNTENA;
+#endif
 
   /* set up the pin for sampling the CAN bus */
 
@@ -1319,7 +1442,9 @@ void setup (void)
   if (digitalRead (CALC_BYTES_PIN) == 0)
       calc_bytes = 2;
 
+#ifdef PLATFORM_TEENSY
   set_arm_clock (180000000);
+#endif
 
   printf ("Build Date:              %s %s\n", __DATE__, __TIME__);
   printf ("CPU Maximum Frequency:   %u\n", F_CPU);

--- a/volvo-cem-cracker.ino
+++ b/volvo-cem-cracker.ino
@@ -28,7 +28,7 @@
 #include <stdarg.h>
 
 #if defined(PLATFORM_STM32)
-#include <CAN.h>           /* STM32 CAN library */
+#include <STM32_CAN.h>     /* STM32 CAN library */
 #else
 #include <FlexCAN_T4.h>
 #endif
@@ -55,8 +55,12 @@ uint32_t cem_reply_max;
 #endif
 
 #if defined(PLATFORM_STM32)
-CANClass can_hs;
-CANClass can_ls;
+STM32_CAN can_hs(CAN1, DEF, RX_SIZE_256, TX_SIZE_16);
+#ifdef CAN2
+STM32_CAN can_ls(CAN2, DEF, RX_SIZE_256, TX_SIZE_16);
+#else
+#define can_ls can_hs
+#endif
 #else
 FlexCAN_T4<CAN1, RX_SIZE_256, TX_SIZE_16> can_hs;
 FlexCAN_T4<CAN2, RX_SIZE_256, TX_SIZE_16> can_ls;
@@ -95,14 +99,6 @@ static inline void serial_printf(const char *fmt, ...)
 #endif
 
 #define CAN_MSG_SIZE    8       /* messages are always 8 bytes */
-
-#if defined(PLATFORM_STM32)
-typedef struct {
-  uint32_t id;
-  uint8_t  buf[CAN_MSG_SIZE];
-  uint8_t  len;
-} CAN_message_t;
-#endif
 
 #define CEM_HS_ECU_ID   0x50    /* CEM ECU id on the high-speed CAN bus */
 #define CEM_LS_ECU_ID   0x40    /* CEM ECU id on the low-speed CAN bus */
@@ -268,15 +264,21 @@ void abortIsr (void)
 #if defined(PLATFORM_STM32)
 void canMsgSend (can_bus_id_t bus, uint32_t id, uint8_t *data, bool verbose)
 {
-  CANClass &can = (bus == CAN_HS) ? can_hs : can_ls;
-  if (verbose) {
-    printf ("CAN_%cS ---> ID=%08x data=%02x %02x %02x %02x %02x %02x %02x %02x\n",
-            bus == CAN_HS ? 'H' : 'L',
-            id, data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7]);
+  STM32_CAN &can = (bus == CAN_HS) ? can_hs : can_ls;
+  CAN_message_t msg;
+
+  if (verbose == true) {
+      printf ("CAN_%cS ---> ID=%08x data=%02x %02x %02x %02x %02x %02x %02x %02x\n",
+              bus == CAN_HS ? 'H' : 'L',
+              id, data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7]);
   }
-  can.beginExtendedPacket(id, CAN_MSG_SIZE);
-  can.write(data, CAN_MSG_SIZE);
-  can.endPacket();
+
+  msg.id = id;
+  msg.len = 8;
+  msg.flags.extended = 1;
+  memcpy (msg.buf, data, 8);
+
+  can.write(msg);
 }
 #else
 void canMsgSend (can_bus_id_t bus, uint32_t id, uint8_t *data, bool verbose)
@@ -328,28 +330,34 @@ volatile bool can_ls_event_msg_available = false;
 bool canMsgReceive (can_bus_id_t bus, uint32_t *id, uint8_t *data, uint32_t wait, bool verbose)
 {
 #if defined(PLATFORM_STM32)
-  CANClass &can = (bus == CAN_HS) ? can_hs : can_ls;
+  STM32_CAN &can = (bus == CAN_HS) ? can_hs : can_ls;
+  CAN_message_t msg;
   uint32_t start = millis();
+  bool ret = false;
+
   while ((millis() - start) < wait) {
-    int packetSize = can.parsePacket();
-    if (packetSize) {
-      uint32_t rxId = can.packetId();
-      if (id)
-        *id = rxId;
-      if (data) {
-        for (int i = 0; i < CAN_MSG_SIZE && i < packetSize; i++)
-          data[i] = can.read();
-      } else {
-        while (can.available())
-          can.read();
-      }
-      if (verbose) {
-        printf("CAN_%cS <--- ID=%08x\n", bus == CAN_HS ? 'H' : 'L', rxId);
-      }
-      return true;
+    if (can.read(msg)) {
+      ret = true;
+      break;
     }
   }
-  return false;
+
+  if (!ret)
+    return false;
+
+  if (id)
+    *id = msg.id;
+  if (data)
+    memcpy(data, msg.buf, CAN_MSG_SIZE);
+
+  if (verbose) {
+    printf("CAN_%cS <--- ID=%08x data=%02x %02x %02x %02x %02x %02x %02x %02x\n",
+           bus == CAN_HS ? 'H' : 'L', msg.id,
+           msg.buf[0], msg.buf[1], msg.buf[2], msg.buf[3],
+           msg.buf[4], msg.buf[5], msg.buf[6], msg.buf[7]);
+  }
+
+  return true;
 #else
   uint8_t *pData;
   uint32_t canId = 0;
@@ -1166,16 +1174,7 @@ bool cemCrackPin (uint32_t maxBytes, bool verbose)
  * Returns: N/A
  */
 
-#if defined(PLATFORM_STM32)
-void can_hs_event(int packetSize)
-{
-  can_hs_event_msg.id = can_hs.packetId();
-  can_hs_event_msg.len = packetSize;
-  for (int i = 0; i < packetSize && i < CAN_MSG_SIZE; i++)
-    can_hs_event_msg.buf[i] = can_hs.read();
-  can_hs_event_msg_available = true;
-}
-#else
+#ifdef PLATFORM_TEENSY
 void can_hs_event (const CAN_message_t &msg)
 {
   can_hs_event_msg = msg;
@@ -1190,16 +1189,7 @@ void can_hs_event (const CAN_message_t &msg)
  * Returns: N/A
  */
 
-#if defined(PLATFORM_STM32)
-void can_ls_event(int packetSize)
-{
-  can_ls_event_msg.id = can_ls.packetId();
-  can_ls_event_msg.len = packetSize;
-  for (int i = 0; i < packetSize && i < CAN_MSG_SIZE; i++)
-    can_ls_event_msg.buf[i] = can_ls.read();
-  can_ls_event_msg_available = true;
-}
-#else
+#ifdef PLATFORM_TEENSY
 void can_ls_event (const CAN_message_t &msg)
 {
   can_ls_event_msg = msg;
@@ -1217,8 +1207,8 @@ void can_ls_event (const CAN_message_t &msg)
 void can_ls_init (uint32_t baud)
 {
 #if defined(PLATFORM_STM32)
-  can_ls.begin(baud);
-  can_ls.onReceive(can_ls_event);
+  can_ls.begin();
+  can_ls.setBaudRate(baud);
 #else
   can_ls.begin ();
   can_ls.setBaudRate (baud);
@@ -1240,8 +1230,8 @@ void can_ls_init (uint32_t baud)
 void can_hs_init (uint32_t baud)
 {
 #if defined(PLATFORM_STM32)
-  can_hs.begin(baud);
-  can_hs.onReceive(can_hs_event);
+  can_hs.begin();
+  can_hs.setBaudRate(baud);
 #else
   can_hs.begin ();
   can_hs.setBaudRate (baud);

--- a/volvo-cem-cracker.ino
+++ b/volvo-cem-cracker.ino
@@ -274,7 +274,7 @@ void canMsgSend (can_bus_id_t bus, uint32_t id, uint8_t *data, bool verbose)
             bus == CAN_HS ? 'H' : 'L',
             id, data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7]);
   }
-  can.beginExtendedPacket(id);
+  can.beginExtendedPacket(id, CAN_MSG_SIZE);
   can.write(data, CAN_MSG_SIZE);
   can.endPacket();
 }
@@ -1167,9 +1167,12 @@ bool cemCrackPin (uint32_t maxBytes, bool verbose)
  */
 
 #if defined(PLATFORM_STM32)
-void can_hs_event(CAN_message_t &msg)
+void can_hs_event(int packetSize)
 {
-  can_hs_event_msg = msg;
+  can_hs_event_msg.id = can_hs.packetId();
+  can_hs_event_msg.len = packetSize;
+  for (int i = 0; i < packetSize && i < CAN_MSG_SIZE; i++)
+    can_hs_event_msg.buf[i] = can_hs.read();
   can_hs_event_msg_available = true;
 }
 #else
@@ -1188,9 +1191,12 @@ void can_hs_event (const CAN_message_t &msg)
  */
 
 #if defined(PLATFORM_STM32)
-void can_ls_event(CAN_message_t &msg)
+void can_ls_event(int packetSize)
 {
-  can_ls_event_msg = msg;
+  can_ls_event_msg.id = can_ls.packetId();
+  can_ls_event_msg.len = packetSize;
+  for (int i = 0; i < packetSize && i < CAN_MSG_SIZE; i++)
+    can_ls_event_msg.buf[i] = can_ls.read();
   can_ls_event_msg_available = true;
 }
 #else
@@ -1212,7 +1218,7 @@ void can_ls_init (uint32_t baud)
 {
 #if defined(PLATFORM_STM32)
   can_ls.begin(baud);
-  can_ls.attachInterrupt(can_ls_event);
+  can_ls.onReceive(can_ls_event);
 #else
   can_ls.begin ();
   can_ls.setBaudRate (baud);
@@ -1235,7 +1241,7 @@ void can_hs_init (uint32_t baud)
 {
 #if defined(PLATFORM_STM32)
   can_hs.begin(baud);
-  can_hs.attachInterrupt(can_hs_event);
+  can_hs.onReceive(can_hs_event);
 #else
   can_hs.begin ();
   can_hs.setBaudRate (baud);


### PR DESCRIPTION
## Summary
- add STM32 platform support helpers
- implement CAN send/receive for Arduino `CAN` library
- fall back to custom printf when Serial.printf missing
- use configurable serial port for K-line

## Testing
- `arduino-cli version` *(fails: command not found)*
- `make -n` *(fails: no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_686a5cae13a8832cb2922fbbe08a3dfc